### PR TITLE
'Fix' division by zero error (Flambo) and NPE (ConvNet)

### DIFF
--- a/src/euroclojure/convnet.clj
+++ b/src/euroclojure/convnet.clj
@@ -220,8 +220,9 @@ euroclojure.convnet
 
     (println "Initializing network...")
     (-> network
-        (.init)
-        (.setListeners (ScoreIterationListener. 1)))
+        (.init))
+        ;; TODO: Fix NPE that occurs when setting listeners. (EQW 28 Nov 2016)
+        ;; (.setListeners (ScoreIterationListener. 1)))
 
     (println "Training model...")
     (.fit scaler data-iter)

--- a/src/euroclojure/flambo.clj
+++ b/src/euroclojure/flambo.clj
@@ -41,8 +41,13 @@
       (f/cache)))
 
 (def testing
-  (-> (.subtract dataset training)
-      (f/cache)))
+  (-> (f/sample dataset false 0.3 1234)
+      (f/cache))
+
+  ;; TODO: Figure out why dataset subtraction is failing. (EQW 28 Nov 2016)
+  ;; (-> (.subtract dataset training)
+  ;;   (f/cache)
+)
 
 (def categorical-features-info
   ;; Feature index 0: sex, two values (M/F)


### PR DESCRIPTION
"Fixes" the division by zero error in Flambo and the NPE in the convolutional neural net. I must have made a mistake when interactively rebasing prior to open sourcing. Still do do:

* Figure out why subtraction in Flambo produces a set of size zero
* Figure out why registering listeners causes an NPE in DL4J

I'll track these as separate issues in the repo.